### PR TITLE
WithTpl() prevents args repetition and enforces msg/attr usage

### DIFF
--- a/internal/handler/handler_with.go
+++ b/internal/handler/handler_with.go
@@ -8,6 +8,7 @@ package handler
 import (
 	"io"
 	"log/slog"
+	"slices"
 
 	"github.com/sfmunoz/logit/internal/color"
 	"github.com/sfmunoz/logit/internal/common"
@@ -67,7 +68,18 @@ func (h *Handler) WithSymbolSet(symbolSet common.SymbolSet) *Handler {
 }
 
 func (h *Handler) WithTpl(tpl ...common.Tpl) slog.Handler {
+	tpl2 := make([]common.Tpl, 0, len(tpl))
+	for _, t := range tpl {
+		if !slices.Contains(tpl2, t) {
+			tpl2 = append(tpl2, t)
+		}
+	}
+	for _, t := range []common.Tpl{common.TplMessage, common.TplAttrs} {
+		if !slices.Contains(tpl2, t) {
+			tpl2 = append(tpl2, t)
+		}
+	}
 	hc := h.clone()
-	hc.tpl = tpl
+	hc.tpl = tpl2
 	return hc
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -34,7 +34,7 @@ func inner(_ *testing.T, symbolSet common.SymbolSet) {
 	slog.Error("DB connection lost", "err", "connection reset", "failure", errors.New("network off"), "db", "myapp")
 	log.Print("log.Print() message")
 	l.Trace("trace", "the-key", "the-val")
-	l.WithTpl(common.TplAttrs, common.TplMessage, common.TplLevel, common.TplUptime).Notice("notice (ad hoc template)", "the-key", "the-val")
+	l.WithTpl(common.TplLevel, common.TplUptime, common.TplUptime, common.TplLevel).Notice("notice (ad hoc template)", "the-key", "the-val")
 	//l.Fatal("fatal", "key", "val")
 	l.WithGroup("s").LogAttrs(context.Background(), common.LevelNotice, "(1) logger.WithGroup(\"s\")", slog.Int("a", 1), slog.Int("b", 2))
 	l.LogAttrs(context.Background(), common.LevelNotice, "(2) logger.WithGroup(\"s\")", slog.Group("s", slog.Int("a", 1), slog.Int("b", 2)))


### PR DESCRIPTION
It's already fixed:

- **WithTpl()** prevents arg repetition from happening
- It also enforces **TplMessage** and **TplAttrs** usage if not in arguments