### PR TITLE
Feature/3 support config with env vars

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -53,7 +53,7 @@ func NewHandler() *Handler {
 		timeFormat: "2006-01-02T15:04:05.000Z07:00",
 		timeOn:     true,
 		uptime:     true,
-		colorObj:   color.NewColor(common.ColorSmart),
+		colorObj:   color.NewColor(LogitColorModeEnv()),
 		symbolSet:  common.SymbolNone,
 		tpl: []common.Tpl{
 			common.TplTime,

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"io"
 	"log/slog"
-	"os"
 	"sync"
 	"time"
 
@@ -45,7 +44,7 @@ func NewHandler() *Handler {
 	return &Handler{
 		attrs:      make([]slog.Attr, 0),
 		groups:     make([]string, 0),
-		out:        os.Stderr,
+		out:        LogitWriterEnv(),
 		tsStart:    time.Now().UTC(),
 		handlers:   make([]slog.Handler, 0),
 		addSource:  false,

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -50,7 +50,7 @@ func NewHandler() *Handler {
 		handlers:   make([]slog.Handler, 0),
 		addSource:  false,
 		level:      common.LevelInfo,
-		timeFormat: "2006-01-02T15:04:05.000Z07:00",
+		timeFormat: LogitTimeFormatEnv(),
 		timeOn:     true,
 		uptime:     true,
 		colorObj:   color.NewColor(LogitColorModeEnv()),

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -47,7 +47,7 @@ func NewHandler() *Handler {
 		level:      LogitLevelEnv(),
 		timeFormat: LogitTimeFormatEnv(),
 		colorObj:   color.NewColor(LogitColorModeEnv()),
-		symbolSet:  common.SymbolNone,
+		symbolSet:  LogitSymbolSetEnv(),
 		tpl: []common.Tpl{
 			common.TplTime,
 			common.TplUptime,

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -49,7 +49,7 @@ func NewHandler() *Handler {
 		tsStart:    time.Now().UTC(),
 		handlers:   make([]slog.Handler, 0),
 		addSource:  false,
-		level:      common.LevelInfo,
+		level:      LogitLevelEnv(),
 		timeFormat: LogitTimeFormatEnv(),
 		timeOn:     true,
 		uptime:     true,

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -56,7 +56,7 @@ func NewHandler() *Handler {
 			common.TplMessage,
 			common.TplAttrs,
 		},
-		uptimeFmt: common.UptimeAdhoc,
+		uptimeFmt: LogitUptimeFormatEnv(),
 	}
 }
 

--- a/internal/handler/handler_env_vars.go
+++ b/internal/handler/handler_env_vars.go
@@ -51,6 +51,16 @@ func LogitTimeFormatEnv() string {
 	return "2006-01-02T15:04:05.000Z07:00"
 }
 
+func LogitUptimeFormatEnv() common.UptimeFormat {
+	switch os.Getenv("LOGIT_UPTIME_FORMAT") {
+	case "std", "STD":
+		return common.UptimeStd
+	case "adhoc", "ADHOC":
+		return common.UptimeAdhoc
+	}
+	return common.UptimeAdhoc // default
+}
+
 func LogitColorModeEnv() common.ColorMode {
 	switch os.Getenv("LOGIT_COLOR_MODE") {
 	case "off", "OFF":

--- a/internal/handler/handler_env_vars.go
+++ b/internal/handler/handler_env_vars.go
@@ -6,11 +6,22 @@
 package handler
 
 import (
+	"io"
 	"log/slog"
 	"os"
 
 	"github.com/sfmunoz/logit/internal/common"
 )
+
+func LogitWriterEnv() io.Writer {
+	switch os.Getenv("LOGIT_WRITER") {
+	case "stdout", "STDOUT":
+		return os.Stdout
+	case "stderr", "STDERR":
+		return os.Stderr
+	}
+	return os.Stderr
+}
 
 func LogitLevelEnv() slog.Level {
 	switch os.Getenv("LOGIT_LEVEL") {

--- a/internal/handler/handler_env_vars.go
+++ b/internal/handler/handler_env_vars.go
@@ -11,6 +11,14 @@ import (
 	"github.com/sfmunoz/logit/internal/common"
 )
 
+func LogitTimeFormatEnv() string {
+	ret := os.Getenv("LOGIT_TIME_FORMAT")
+	if ret != "" {
+		return ret
+	}
+	return "2006-01-02T15:04:05.000Z07:00"
+}
+
 func LogitColorModeEnv() common.ColorMode {
 	switch os.Getenv("LOGIT_COLOR_MODE") {
 	case "off", "OFF":

--- a/internal/handler/handler_env_vars.go
+++ b/internal/handler/handler_env_vars.go
@@ -1,0 +1,26 @@
+//
+// Author: 46285520+sfmunoz@users.noreply.github.com
+// URL:    https://github.com/sfmunoz/logit
+//
+
+package handler
+
+import (
+	"os"
+
+	"github.com/sfmunoz/logit/internal/common"
+)
+
+func LogitColorModeEnv() common.ColorMode {
+	switch os.Getenv("LOGIT_COLOR_MODE") {
+	case "off", "OFF":
+		return common.ColorOff
+	case "smart", "SMART":
+		return common.ColorSmart
+	case "medium", "MEDIUM":
+		return common.ColorMedium
+	case "full", "FULL":
+		return common.ColorFull
+	}
+	return common.ColorSmart // default
+}

--- a/internal/handler/handler_env_vars.go
+++ b/internal/handler/handler_env_vars.go
@@ -6,10 +6,31 @@
 package handler
 
 import (
+	"log/slog"
 	"os"
 
 	"github.com/sfmunoz/logit/internal/common"
 )
+
+func LogitLevelEnv() slog.Level {
+	switch os.Getenv("LOGIT_LEVEL") {
+	case "trace", "TRACE":
+		return common.LevelTrace
+	case "debug", "DEBUG":
+		return common.LevelDebug
+	case "info", "INFO":
+		return common.LevelInfo
+	case "notice", "NOTICE":
+		return common.LevelNotice
+	case "warn", "WARN":
+		return common.LevelWarn
+	case "error", "ERROR":
+		return common.LevelError
+	case "fatal", "FATAL":
+		return common.LevelFatal
+	}
+	return common.LevelInfo // default
+}
 
 func LogitTimeFormatEnv() string {
 	ret := os.Getenv("LOGIT_TIME_FORMAT")

--- a/internal/handler/handler_env_vars.go
+++ b/internal/handler/handler_env_vars.go
@@ -74,3 +74,15 @@ func LogitColorModeEnv() common.ColorMode {
 	}
 	return common.ColorSmart // default
 }
+
+func LogitSymbolSetEnv() common.SymbolSet {
+	switch os.Getenv("LOGIT_SYMBOL_SET") {
+	case "none", "NONE":
+		return common.SymbolNone
+	case "unicode_up", "UNICODE_UP":
+		return common.SymbolUnicodeUp
+	case "unicode_down", "UNICODE_DOWN":
+		return common.SymbolUnicodeDown
+	}
+	return common.SymbolNone // default
+}


### PR DESCRIPTION
Env var config support created throughout several changes:

- LogitWriterEnv() → LOGIT_WRITER
- LogitLevelEnv() → LOGIT_LEVEL
- LogitTimeFormatEnv() → LOGIT_TIME_FORMAT
- LogitUptimeFormatEnv() → LOGIT_UPTIME_FORMAT
- LogitColorModeEnv() → LOGIT_COLOR_MODE
- LogitSymbolSetEnv() → LOGIT_SYMBOL_SET