### PR TITLE
Feature/5 handler replace attr

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -40,24 +40,26 @@ var lMap = map[common.SymbolSet]map[slog.Level]string{
 }
 
 type Buffer struct {
-	arr       []string
-	timeFmt   string
-	col       *color.Color
-	tsStart   time.Time
-	groups    []string
-	symbolSet common.SymbolSet
-	uptimeFmt common.UptimeFormat
+	arr         []string
+	timeFmt     string
+	col         *color.Color
+	tsStart     time.Time
+	groups      []string
+	symbolSet   common.SymbolSet
+	uptimeFmt   common.UptimeFormat
+	replaceAttr common.ReplaceAttr
 }
 
-func NewBuffer(timeFmt string, col *color.Color, tsStart time.Time, groups []string, symbolSet common.SymbolSet, uptimeFmt common.UptimeFormat) *Buffer {
+func NewBuffer(timeFmt string, col *color.Color, tsStart time.Time, groups []string, symbolSet common.SymbolSet, uptimeFmt common.UptimeFormat, replaceAttr common.ReplaceAttr) *Buffer {
 	return &Buffer{
-		arr:       make([]string, 0, 20),
-		timeFmt:   timeFmt,
-		col:       col,
-		tsStart:   tsStart,
-		groups:    groups,
-		symbolSet: symbolSet,
-		uptimeFmt: uptimeFmt,
+		arr:         make([]string, 0, 20),
+		timeFmt:     timeFmt,
+		col:         col,
+		tsStart:     tsStart,
+		groups:      groups,
+		symbolSet:   symbolSet,
+		uptimeFmt:   uptimeFmt,
+		replaceAttr: replaceAttr,
 	}
 }
 

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -123,6 +123,12 @@ func (b *Buffer) PushAttr(attr slog.Attr) {
 	if attr.Equal(slog.Attr{}) || attr.Key == "" {
 		return
 	}
+	if b.replaceAttr != nil {
+		// naive support: groups are ignored
+		if attrNew := b.replaceAttr(nil, attr); !attrNew.Equal(slog.Attr{}) {
+			attr = attrNew
+		}
+	}
 	kind := attr.Value.Kind()
 	if kind == slog.KindGroup {
 		for _, a := range attr.Value.Group() {

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -11,6 +11,7 @@ type ColorMode int
 type SymbolSet int
 type Tpl int
 type UptimeFormat int
+type ReplaceAttr func(groups []string, a slog.Attr) slog.Attr
 
 const (
 	LevelTrace  = slog.Level(-8)  // new

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -26,12 +26,13 @@ type Handler struct {
 	tsStart  time.Time
 	handlers []slog.Handler
 
-	level      slog.Leveler
-	timeFormat string
-	colorObj   *color.Color
-	symbolSet  common.SymbolSet
-	tpl        []common.Tpl
-	uptimeFmt  common.UptimeFormat
+	level       slog.Leveler
+	timeFormat  string
+	colorObj    *color.Color
+	symbolSet   common.SymbolSet
+	tpl         []common.Tpl
+	uptimeFmt   common.UptimeFormat
+	replaceAttr common.ReplaceAttr
 }
 
 func NewHandler() *Handler {
@@ -56,23 +57,25 @@ func NewHandler() *Handler {
 			common.TplMessage,
 			common.TplAttrs,
 		},
-		uptimeFmt: LogitUptimeFormatEnv(),
+		uptimeFmt:   LogitUptimeFormatEnv(),
+		replaceAttr: nil,
 	}
 }
 
 func (h *Handler) clone() *Handler {
 	return &Handler{
-		attrs:      h.attrs,  // no clone intended
-		groups:     h.groups, // no clone intended
-		out:        h.out,
-		tsStart:    h.tsStart,
-		handlers:   h.handlers, // no clone intended
-		level:      h.level,
-		timeFormat: h.timeFormat,
-		colorObj:   h.colorObj, // no clone intended
-		symbolSet:  h.symbolSet,
-		tpl:        h.tpl, // no clone intended
-		uptimeFmt:  h.uptimeFmt,
+		attrs:       h.attrs,  // no clone intended
+		groups:      h.groups, // no clone intended
+		out:         h.out,
+		tsStart:     h.tsStart,
+		handlers:    h.handlers, // no clone intended
+		level:       h.level,
+		timeFormat:  h.timeFormat,
+		colorObj:    h.colorObj, // no clone intended
+		symbolSet:   h.symbolSet,
+		tpl:         h.tpl, // no clone intended
+		uptimeFmt:   h.uptimeFmt,
+		replaceAttr: h.replaceAttr,
 	}
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -87,7 +87,7 @@ func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
 	for _, hh := range h.handlers {
 		_ = hh.Handle(ctx, r.Clone())
 	}
-	buf := buffer.NewBuffer(h.timeFormat, h.colorObj, h.tsStart, h.groups, h.symbolSet, h.uptimeFmt)
+	buf := buffer.NewBuffer(h.timeFormat, h.colorObj, h.tsStart, h.groups, h.symbolSet, h.uptimeFmt, h.replaceAttr)
 	for _, tpl := range h.tpl {
 		switch tpl {
 		case common.TplTime:

--- a/internal/handler/handler_with.go
+++ b/internal/handler/handler_with.go
@@ -83,3 +83,9 @@ func (h *Handler) WithTpl(tpl ...common.Tpl) slog.Handler {
 	hc.tpl = tpl2
 	return hc
 }
+
+func (h *Handler) WithReplaceAttr(replaceAttr common.ReplaceAttr) *Handler {
+	c := h.clone()
+	c.replaceAttr = replaceAttr
+	return c
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -18,13 +18,21 @@ import (
 	"github.com/sfmunoz/logit/internal/logger"
 )
 
+func replaceAttr(_ []string, a slog.Attr) slog.Attr {
+	if a.Key == "the-key" {
+		return slog.String("the-key", fmt.Sprintf("'%s'=>EXTENDED BY 'replaceAttr()'", a.Value))
+	}
+	return slog.Attr{}
+}
+
 func inner(_ *testing.T, symbolSet common.SymbolSet) {
 	l := logger.NewLogger(nil).
 		With("a1", "v1").
 		WithGroup("g1").
 		WithGroup("g2").
 		WithLevel(common.LevelTrace).
-		WithSymbolSet(symbolSet)
+		WithSymbolSet(symbolSet).
+		WithReplaceAttr(replaceAttr)
 	slog.SetDefault(l.Logger)
 	l.Info("symbols", "SymbolNone", common.SymbolNone, "SymbolUnicodeUp", common.SymbolUnicodeUp, "SymbolUnicodeDown", common.SymbolUnicodeDown, "Current", symbolSet)
 	l.Info("logger.NewLogger()", "type", fmt.Sprintf("%T", l))

--- a/internal/logger/logger_with.go
+++ b/internal/logger/logger_with.go
@@ -82,3 +82,10 @@ func (l *Logger) WithTpl(tpl ...common.Tpl) *Logger {
 	}
 	return l
 }
+
+func (l *Logger) WithReplaceAttr(replaceAttr common.ReplaceAttr) *Logger {
+	if h, ok := l.Logger.Handler().(*handler.Handler); ok {
+		return NewLogger(h.WithReplaceAttr(replaceAttr))
+	}
+	return l
+}


### PR DESCRIPTION
Basic implementation ready:

- **handler.WithReplaceAttr()** and **logger.WithReplaceAttr()** created
- **handler.replaceAttr** and **buffer.replaceAttr** created as well
- **buffer.PushAttr()** makes naive use of **buffer.replaceAttr**
  - slog.Attr is used
  - groups[] ignored

A separate issue will be created to manage groups[]