### PR TITLE
Bugfix/10 source inconsistency

### DIFF
--- a/logit_test.go
+++ b/logit_test.go
@@ -19,11 +19,24 @@ func TestNewLogit(t *testing.T) {
 		With("test", "NewLogit").
 		WithSymbolSet(logit.SymbolUnicodeDown).
 		WithUptimeFormat(logit.UptimeStd)
-
 	log.Trace("trace-msg")
 	log.Debug("debug-msg")
 	log.Info("info-msg")
 	log.Notice("notice-msg", "duration", 2*time.Hour+5*time.Minute+3*time.Second+427*time.Millisecond)
 	log.Warn("warn-msg")
 	log.Error("error-msg")
+}
+
+func TestSource(t *testing.T) {
+	log := logit.Logit().
+		WithLevel(logit.LevelTrace).
+		WithSymbolSet(logit.SymbolUnicodeDown).
+		WithTpl(logit.TplUptime, logit.TplLevel, logit.TplSource)
+	log.Trace("trace (logit)")
+	log.Debug("debug (slog)")
+	log.Info("info (slog)")
+	log.Notice("notice (logit)")
+	log.Warn("warn (slog)")
+	log.Error("error (slog)")
+	log.Fatal("fatal (logit)")
 }


### PR DESCRIPTION
It's been fixed by [05e1060](https://github.com/sfmunoz/logit/commit/05e1060932a03ab24f78310c9db512408a67b05d):

## OLD (KO)

```
➜  logit git:(bugfix/10-source-inconsistency) go test -v ./... -run TestSource
=== RUN   TestSource
0d00h00m00.000s ⓣ <logger/logger.go:41> trace (logit)
0d00h00m00.000s ⓓ <logit/logit_test.go:36> debug (slog)
0d00h00m00.000s ⓓ <logit/logit_test.go:37> info (slog)
0d00h00m00.000s ⓝ <logger/logger.go:49> notice (logit)
0d00h00m00.000s ⓦ <logit/logit_test.go:39> warn (slog)
0d00h00m00.000s ⓔ <logit/logit_test.go:40> error (slog)
0d00h00m00.000s ⓕ <logger/logger.go:57> fatal (logit)
(...)
```

## NEW (OK)

```
➜  logit git:(bugfix/10-source-inconsistency) go test -v ./... -run TestSource
=== RUN   TestSource
0d00h00m00.000s ⓣ <logit/logit_test.go:35> trace (logit)
0d00h00m00.000s ⓓ <logit/logit_test.go:36> debug (slog)
0d00h00m00.000s ⓓ <logit/logit_test.go:37> info (slog)
0d00h00m00.000s ⓝ <logit/logit_test.go:38> notice (logit)
0d00h00m00.000s ⓦ <logit/logit_test.go:39> warn (slog)
0d00h00m00.000s ⓔ <logit/logit_test.go:40> error (slog)
0d00h00m00.000s ⓕ <logit/logit_test.go:41> fatal (logit)
```