### PR TITLE
Bugfix/20 handler clone

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -43,3 +43,35 @@ const (
 
 	RootGroup = "__root__"
 )
+
+func AttrCopy(attr slog.Attr) slog.Attr {
+	_copy := func(val slog.Value) slog.Value {
+		switch val.Kind() {
+		case slog.KindGroup:
+			gv := val.Group()
+			g := make([]slog.Attr, len(gv))
+			for i, attr := range gv {
+				g[i] = AttrCopy(attr)
+			}
+			return slog.GroupValue(g...)
+		case slog.KindAny:
+			any := val.Any()
+			switch v := any.(type) {
+			case []slog.Attr:
+				g := make([]slog.Attr, len(v))
+				for i, attr := range v {
+					g[i] = AttrCopy(attr)
+				}
+				return slog.AnyValue(g)
+			default:
+				return val // shallow
+			}
+		default:
+			return val
+		}
+	}
+	return slog.Attr{
+		Key:   attr.Key,
+		Value: _copy(attr.Value),
+	}
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -37,6 +37,7 @@ type Handler struct {
 
 	level       slog.Leveler
 	timeFormat  string
+	colorMode   common.ColorMode
 	colorObj    *color.Color
 	symbolSet   common.SymbolSet
 	tpl         []common.Tpl
@@ -48,6 +49,7 @@ func NewHandler() *Handler {
 	// time.RFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
 	// time.StampMilli = "Jan _2 15:04:05.000"
 	// 999: drops trailing 0; 000: keeps trailing 0
+	colorMode := LogitColorModeEnv()
 	return &Handler{
 		attrs:      make([]attr, 0),
 		out:        LogitWriterEnv(),
@@ -55,7 +57,8 @@ func NewHandler() *Handler {
 		handlers:   make([]slog.Handler, 0),
 		level:      LogitLevelEnv(),
 		timeFormat: LogitTimeFormatEnv(),
-		colorObj:   color.NewColor(LogitColorModeEnv()),
+		colorMode:  colorMode,
+		colorObj:   color.NewColor(colorMode),
 		symbolSet:  LogitSymbolSetEnv(),
 		tpl: []common.Tpl{
 			common.TplTime,
@@ -78,7 +81,8 @@ func (h *Handler) clone() *Handler {
 		handlers:    h.handlers, // no clone intended
 		level:       h.level,
 		timeFormat:  h.timeFormat,
-		colorObj:    h.colorObj, // no clone intended
+		colorMode:   h.colorMode,
+		colorObj:    color.NewColor(h.colorMode),
 		symbolSet:   h.symbolSet,
 		tpl:         make([]common.Tpl, len(h.tpl)),
 		uptimeFmt:   h.uptimeFmt,

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -71,7 +71,7 @@ func NewHandler() *Handler {
 }
 
 func (h *Handler) clone() *Handler {
-	return &Handler{
+	ret := &Handler{
 		attrs:       h.attrs, // no clone intended
 		out:         h.out,
 		tsStart:     h.tsStart,
@@ -80,10 +80,12 @@ func (h *Handler) clone() *Handler {
 		timeFormat:  h.timeFormat,
 		colorObj:    h.colorObj, // no clone intended
 		symbolSet:   h.symbolSet,
-		tpl:         h.tpl, // no clone intended
+		tpl:         make([]common.Tpl, len(h.tpl)),
 		uptimeFmt:   h.uptimeFmt,
 		replaceAttr: h.replaceAttr,
 	}
+	copy(ret.tpl, h.tpl)
+	return ret
 }
 
 func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -72,7 +72,7 @@ func NewHandler() *Handler {
 
 func (h *Handler) clone() *Handler {
 	ret := &Handler{
-		attrs:       h.attrs, // no clone intended
+		attrs:       make([]attr, len(h.attrs)),
 		out:         h.out,
 		tsStart:     h.tsStart,
 		handlers:    h.handlers, // no clone intended
@@ -83,6 +83,12 @@ func (h *Handler) clone() *Handler {
 		tpl:         make([]common.Tpl, len(h.tpl)),
 		uptimeFmt:   h.uptimeFmt,
 		replaceAttr: h.replaceAttr,
+	}
+	for i, a := range h.attrs {
+		ret.attrs[i] = attr{
+			Attr:      common.AttrCopy(a.Attr),
+			withGroup: a.withGroup,
+		}
 	}
 	copy(ret.tpl, h.tpl)
 	return ret

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -159,8 +159,8 @@ func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	hc := h.clone()
 	l := len(h.attrs)
 	hc.attrs = make([]attr, l+len(attrs))
-	if l > 0 {
-		copy(hc.attrs, h.attrs)
+	for i, a := range h.attrs {
+		hc.attrs[i] = attr{Attr: common.AttrCopy(a.Attr), withGroup: a.withGroup}
 	}
 	for i, a := range attrs {
 		hc.attrs[l+i] = attr{Attr: a, withGroup: false}
@@ -175,8 +175,8 @@ func (h *Handler) WithGroup(name string) slog.Handler {
 	hc := h.clone()
 	l := len(h.attrs)
 	hc.attrs = make([]attr, l+1)
-	if l > 0 {
-		copy(hc.attrs, h.attrs)
+	for i, a := range h.attrs {
+		hc.attrs[i] = attr{Attr: common.AttrCopy(a.Attr), withGroup: a.withGroup}
 	}
 	hc.attrs[l] = attr{Attr: slog.Group(name), withGroup: true}
 	return hc

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -78,7 +78,7 @@ func (h *Handler) clone() *Handler {
 		attrs:       make([]attr, len(h.attrs)),
 		out:         h.out,
 		tsStart:     h.tsStart,
-		handlers:    h.handlers, // no clone intended
+		handlers:    make([]slog.Handler, len(h.handlers)),
 		level:       h.level,
 		timeFormat:  h.timeFormat,
 		colorMode:   h.colorMode,
@@ -94,6 +94,7 @@ func (h *Handler) clone() *Handler {
 			withGroup: a.withGroup,
 		}
 	}
+	copy(ret.handlers, h.handlers)
 	copy(ret.tpl, h.tpl)
 	return ret
 }

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -49,7 +49,8 @@ func TestFanout(t *testing.T) {
 	h2 := slog.NewJSONHandler(os.Stderr, opts2)
 	h := handler.NewHandler().
 		WithLeveler(lv).
-		WithHandlers([]slog.Handler{h1, h2})
+		WithHandlers([]slog.Handler{h1, h2}).
+		WithColor(false)
 	logger := slog.New(h)
 	slog.SetDefault(logger)
 	slog.Info("Message repeated", "times", 3)

--- a/internal/handler/handler_with.go
+++ b/internal/handler/handler_with.go
@@ -44,6 +44,7 @@ func (h *Handler) WithUptimeFormat(uptimeFmt common.UptimeFormat) *Handler {
 
 func (h *Handler) WithColorMode(cm common.ColorMode) *Handler {
 	c := h.clone()
+	c.colorMode = cm
 	c.colorObj = color.NewColor(cm)
 	return c
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -29,14 +29,27 @@ func NewLogger(h slog.Handler) *Logger {
 	return &Logger{logInner}
 }
 
+func (l *Logger) clone() *Logger {
+	c := *l
+	return &c
+}
+
 func (l *Logger) With(args ...any) *Logger {
-	l.Logger = l.Logger.With(args...)
-	return l
+	if len(args) == 0 {
+		return l
+	}
+	c := l.clone()
+	c.Logger = l.Logger.With(args...)
+	return c
 }
 
 func (l *Logger) WithGroup(name string) *Logger {
-	l.Logger = l.Logger.WithGroup(name)
-	return l
+	if name == "" {
+		return l
+	}
+	c := l.clone()
+	c.Logger = l.Logger.WithGroup(name)
+	return c
 }
 
 func (l *Logger) Trace(msg string, args ...any) {


### PR DESCRIPTION
Aliasing issues must be gone with the following changes:

- **Handler.tpl** is cloned instead of aliased
- **Handler.attrs** cloned instead of aliased (**common.AttrCopy()** created)
- **Handler.WithAttrs()** and **Handler.WithGroup()** fixed to use **common.AttrCopy()**
- **Logger.With()** and **Logger.WithGroup()** use newly created **Logger.clone()**
- **Handler.colorObj** recreated instead of aliased
- **Handler.handlers** cloned instead of aliased