### PR TITLE
buffer.go: Push*() args updated from slog.Record/slog.Attr to *slog.Record/*slog.Attr

### DIFF
--- a/internal/buffer/buffer_test.go
+++ b/internal/buffer/buffer_test.go
@@ -26,14 +26,14 @@ const timePat = `2[0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([0-1][0-9
 var colorOff = color.NewColor(common.ColorOff)
 var tsStart = time.Now().UTC()
 
-func record(msg string, args ...any) slog.Record {
+func record(msg string, args ...any) *slog.Record {
 	var pc uintptr
 	var pcs [1]uintptr
 	runtime.Callers(3, pcs[:])
 	pc = pcs[0]
 	r := slog.NewRecord(time.Now(), logit.LevelInfo, msg, pc)
 	r.Add(args...)
-	return r
+	return &r
 }
 
 func assert(t *testing.T, buf *buffer.Buffer, re string) {
@@ -79,7 +79,8 @@ func TestBuffer3(t *testing.T) {
 
 func TestBuffer4(t *testing.T) {
 	r := record("hello")
-	buf := simpleBuf().PushLevel(r).PushMessage(r).PushAttr(slog.Int("k1", 111))
+	a := slog.Int("k1", 111)
+	buf := simpleBuf().PushLevel(r).PushMessage(r).PushAttr(&a)
 	assert(t, buf, `^\[I] hello k1=111$`)
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -111,15 +111,15 @@ func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
 	for _, tpl := range h.tpl {
 		switch tpl {
 		case common.TplTime:
-			buf.PushTime(r)
+			buf.PushTime(&r)
 		case common.TplUptime:
-			buf.PushUptime(r)
+			buf.PushUptime(&r)
 		case common.TplLevel:
-			buf.PushLevel(r)
+			buf.PushLevel(&r)
 		case common.TplSource:
-			buf.PushSource(r)
+			buf.PushSource(&r)
 		case common.TplMessage:
-			buf.PushMessage(r)
+			buf.PushMessage(&r)
 		case common.TplAttrs:
 			g0 := make([][]any, 0)
 			g1 := []any{common.RootGroup}
@@ -145,7 +145,7 @@ func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
 				gtmp := slog.Group(attrs[0].(string), attrs[1:]...)
 				gRoot = &gtmp
 			}
-			buf.PushAttr(*gRoot)
+			buf.PushAttr(gRoot)
 		}
 	}
 	if buf.Len() == 0 {


### PR DESCRIPTION
It's done: buffer.go: Push*() methods arg updated from slog.Record/slog.Attr to *slog.Record/*slog.Attr